### PR TITLE
Python: Support for `validate_all` function

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -10,13 +10,20 @@ in `validate.proto`. Implemented Python annotations are listed in the [rules com
 from entities_pb2 import Person
 from protoc_gen_validate.validator import validate, ValidationFailed, validate_all
 
-p = Person(first_name="Foo", last_name="Bar", age=42)
+p = Person(name="Foo")
 try:
     validate(p)
-    # you can also validate all rules
-    # validate_all(p)
 except ValidationFailed as err:
-    print(err)
+    print(err)  # p.id is not greater than 999
+    
+try:
+    validate_all(p)
+except ValidationFailed as err:
+    print(err)  
+    # p.id is not greater than 999
+    # p.email is not a valid email
+    # p.name pattern does not match ^[^[0-9]A-Za-z]+( [^[0-9]A-Za-z]+)*$
+    # home is required.
 ```
 
 [pgv-home]: https://github.com/envoyproxy/protoc-gen-validate

--- a/python/README.md
+++ b/python/README.md
@@ -8,11 +8,13 @@ in `validate.proto`. Implemented Python annotations are listed in the [rules com
 ### Example
 ```python3
 from entities_pb2 import Person
-from protoc_gen_validate.validator import validate, ValidationFailed
+from protoc_gen_validate.validator import validate, ValidationFailed, validate_all
 
 p = Person(first_name="Foo", last_name="Bar", age=42)
 try:
     validate(p)
+    # you can also validate all rules
+    # validate_all(p)
 except ValidationFailed as err:
     print(err)
 ```

--- a/python/protoc_gen_validate/validator.py
+++ b/python/protoc_gen_validate/validator.py
@@ -12,7 +12,6 @@ from google.protobuf.message import Message
 from jinja2 import Template
 from validate_email import validate_email
 
-
 if sys.version_info > (3, 9):
     unparse = ast.unparse
 else:

--- a/python/requirements.in
+++ b/python/requirements.in
@@ -4,3 +4,4 @@
 validate-email>=1.3
 Jinja2>=2.11.1
 protobuf>=3.6.1
+astunparse>=1.6.3

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -21,6 +21,7 @@ install_requires =
     validate-email>=1.3
     Jinja2>=2.11.1
     protobuf>=3.6.1
+    astunparse>=1.6.3
 python_requires = >=3.6
 
 [options.data_files]

--- a/tests/harness/python/harness.py
+++ b/tests/harness/python/harness.py
@@ -1,7 +1,7 @@
 import sys
 import inspect
 
-from python.protoc_gen_validate.validator import validate, ValidationFailed
+from python.protoc_gen_validate.validator import validate, validate_all, ValidationFailed
 
 from tests.harness.harness_pb2 import TestCase, TestResult
 from tests.harness.cases.bool_pb2 import *
@@ -20,7 +20,6 @@ from tests.harness.cases.wkt_nested_pb2 import *
 from tests.harness.cases.wkt_wrappers_pb2 import *
 from tests.harness.cases.wkt_timestamp_pb2 import *
 from tests.harness.cases.kitchen_sink_pb2 import *
-
 
 message_classes = {}
 for k, v in inspect.getmembers(sys.modules[__name__], inspect.isclass):
@@ -45,6 +44,26 @@ if __name__ == "__main__":
     except ValidationFailed as e:
         result.Valid = False
         result.Reasons[:] = [repr(e)]
+
+    try:
+        result_all = TestResult()
+        valid = validate_all(test_msg)
+        result_all.Valid = True
+    except ValidationFailed as e:
+        result_all.Valid = False
+        result_all.Reasons[:] = [repr(e)]
+
+    if result.Valid != result_all.Valid:
+        raise ValueError(f"validation results mismatch, validate: {result.Valid}, "
+                         f"validate_all: {result_all.Valid}")
+    if not result.Valid:
+        reason = list(result.Reasons)[0]  # ValidationFailed("reason")
+        reason = reason[18:-2]  # reason
+        reason_all = list(result_all.Reasons)[0]  # ValidationFailed("reason1\nreason2\n...reason")
+        reason_all = reason_all[18:-2]  # reason1\nreason2\n...reason
+        if not reason_all.startswith(reason):
+            raise ValueError(f"different first message, validate: {reason}, "
+                             f"validate_all: {reason_all}")
 
     sys.stdout = open(sys.stdout.fileno(), mode='w', encoding='utf8')
     sys.stdout.write(result.SerializeToString().decode("utf-8"))


### PR DESCRIPTION
This change implements the `validate_all` function through the [ast](https://docs.python.org/3/library/ast.html) module in the python standard library, which allows PGV to return all validate error messages at once.

```proto
//entities.proto
message Person {
  uint64 id    = 1 [(validate.rules).uint64.gt    = 999];

  string email = 2 [(validate.rules).string.email = true];

  string name  = 3 [(validate.rules).string = {
                      pattern:   "^[^[0-9]A-Za-z]+( [^[0-9]A-Za-z]+)*$",
                      max_bytes: 256,
                   }];

  Location home = 4 [(validate.rules).message.required = true];

  message Location {
    double lat = 1 [(validate.rules).double = { gte: -90,  lte: 90 }];
    double lng = 2 [(validate.rules).double = { gte: -180, lte: 180 }];
  }
}
```

```python
from entities_pb2 import Person
from protoc_gen_validate.validator import validate, ValidationFailed, print_validate, validate_all


p = Person(id=1000, name="Foo", email=".bar@bad.co", home=Person.Location(lat=0, lng=-999))
try:
    validate(p)
except ValidationFailed as err:
    print("validate(p):", err)
print("=" * 79)
try:
    validate_all(p)
except ValidationFailed as err:
    print("validate_all(p):", err)

print("=" * 79)
print(print_validate())
```

Result:

```
validate(p): p.email is not a valid email
===============================================================================
validate_all(p): 
p.email is not a valid email
p.name pattern does not match ^[^[0-9]A-Za-z]+( [^[0-9]A-Za-z]+)*$
p.lng is not in range (180.0, -180.0)
===============================================================================
# Validates Person
def generate_validate(p):
    if p.id <= 999:
        raise ValidationFailed("p.id is not greater than 999")
    if not _validateEmail(p.email):
        raise ValidationFailed("p.email is not a valid email")
    if byte_len(p.name) > 256:
        raise ValidationFailed("p.name length is greater than 256")
    if re.search(r'^[^[0-9]A-Za-z]+( [^[0-9]A-Za-z]+)*$', p.name) is None:
        raise ValidationFailed("p.name pattern does not match ^[^[0-9]A-Za-z]+( [^[0-9]A-Za-z]+)*$")
    if not _has_field(p, "home"):
        raise ValidationFailed("home is required.")
    if _has_field(p, "home"):
        embedded = validate(p.home)
        if embedded is not None:
            return embedded
    return None
# Validates Person All
def generate_validate_all(p):
    err = ''
    if p.id <= 999:
        err += '\np.id is not greater than 999'
    if not _validateEmail(p.email):
        err += '\np.email is not a valid email'
    if byte_len(p.name) > 256:
        err += '\np.name length is greater than 256'
    if re.search('^[^[0-9]A-Za-z]+( [^[0-9]A-Za-z]+)*$', p.name) is None:
        err += '\np.name pattern does not match ^[^[0-9]A-Za-z]+( [^[0-9]A-Za-z]+)*$'
    if not _has_field(p, 'home'):
        err += '\nhome is required.'
    if _has_field(p, 'home'):
        err += _validate_all(p.home)
    return err
# Validates Location All
def generate_validate_all(p):
    err = ''
    if p.lat < -90.0 or p.lat > 90.0:
        err += '\np.lat is not in range (90.0, -90.0)'
    if p.lng < -180.0 or p.lng > 180.0:
        err += '\np.lng is not in range (180.0, -180.0)'
    return err
```

