### PR TITLE
TCN-548 fix Python CI syntax error

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -1,6 +1,7 @@
 name: Release Python Package
 
 on:
+  pull_request:
   push:
     tags:
       - 'v*.*.*'
@@ -25,9 +26,8 @@ jobs:
           load: true
           push: false
           tags: ${{ env.IMAGE_TAG }}
-      - name: Run
       - run: |
           docker run --rm \
           --env PYPI_REPO=pypi \
-          --env PGV_PYPI_TOKEN="${{ secrets.PGV_PYPI_TOKEN }}" \
+#          --env PGV_PYPI_TOKEN="${{ secrets.PGV_PYPI_TOKEN }}" \
           ${{ env.IMAGE_TAG }} python-release


### PR DESCRIPTION
A few issued…

- [x] some syntax error:

```sh
Error: .github#L1
every step must define a `uses` or `run` key
```

- [ ] Version in [setup.cfg](https://github.com/bufbuild/protoc-gen-validate/blob/1ffafd993b2524c7173e7bdd56e23b8bc8bb7c7a/python/setup.cfg#L3) not programmatically configurable