### PR TITLE
Upgrade zlib to 1.2.13 to resolve CI failure

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -39,9 +39,9 @@ def pgv_dependencies(maven_repos = _DEFAULT_REPOSITORIES):
         http_archive(
             name = "zlib",
             build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
-            sha256 = "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9",
-            strip_prefix = "zlib-1.2.12",
-            urls = ["https://zlib.net/zlib-1.2.12.tar.gz"],
+            sha256 = "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30",
+            strip_prefix = "zlib-1.2.13",
+            urls = ["https://zlib.net/zlib-1.2.13.tar.gz"],
         )
 
     if not native.existing_rule("bazel_skylib"):


### PR DESCRIPTION
[zlib 1.2.13 release notes](https://github.com/madler/zlib/releases/tag/v1.2.13) Fix a bug when getting a gzip header extra field with inflateGetHeader(). This remedies [CVE-2022-37434](https://nvd.nist.gov/vuln/detail/CVE-2022-37434). Due to the bug fix, any installations of 1.2.12 or earlier should be replaced with 1.2.13.
