### PR TITLE
TCN-464 fix goreleaser syntax

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -1,10 +1,9 @@
 name: goreleaser
 
 on:
-  pull_request:
   push:
     tags:
-      - "*"
+      - 'v*.*.*'
 
 permissions:
   contents: write
@@ -19,7 +18,7 @@ jobs:
       - run: git fetch --force --tags
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.1
+          go-version: 1.19.x
           cache: true
       - uses: goreleaser/goreleaser-action@v2
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,11 +1,4 @@
-# .goreleaser.yaml
 release:
-  # Repo in which the release will be created.
-  # Default is extracted from the origin remote URL or empty if its private hosted.
-  github:
-    owner: ElliotMJackson
-    name: protoc-gen-validate
-
   # If set to true, will not auto-publish the release.
   # Available only for GitHub and Gitea.
   # Default is false.
@@ -45,33 +38,6 @@ release:
   # Default is `keep-existing`.
   mode: keep-existing
 
-  # Header template for the release body.
-  # Defaults to empty.
-  header: |
-    ## Some title ({{ .Date }})
-
-    Welcome to this new release!
-
-  # Footer template for the release body.
-  # Defaults to empty.
-  footer: |
-    ## Thanks!
-
-    Those were the changes on {{ .Tag }}!
-
   # You can change the name of the release.
   # Default is `{{.Tag}}` on OSS and `{{.PrefixedTag}}` on Pro.
   name_template: "{{.Tag}}"
-
-  # You can disable this pipe in order to not create the release on any SCM.
-  # Keep in mind that this might also break things that depend on the release URL, for instance, homebrew taps.
-  #
-  # Defaults to false.
-  disable: false
-
-  # Set this to true if you want to disable just the artifact upload to the SCM.
-  # If this is true, GoReleaser will still create the release with the changelog, but won't upload anything to it.
-  #
-  # Default: false.
-  # Since: v1.11.
-  skip_upload: false


### PR DESCRIPTION
1. Go Releaser is configured to `keep-existing` release comments so this will use the Github auto-generated release content. There is no need to expand on this
2. A series of configurable items are set to defaults, these have been removed from config. 
3. Some information was left over from my branch, this has been removed