### PR TITLE
GH-680 add linux aarch x64 support to pom

### DIFF
--- a/java/pgv-artifacts/pom.xml
+++ b/java/pgv-artifacts/pom.xml
@@ -139,6 +139,26 @@
                             </environmentVariables>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>linux-aarch_64</id>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>compile</phase>
+                        <configuration>
+                            <executable>go</executable>
+                            <arguments>
+                                <argument>build</argument>
+                                <argument>-o</argument>
+                                <argument>${project.build.directory}/protoc-gen-validate-${project.version}-linux-aarch_64.exe</argument>
+                                <argument>../..</argument>
+                            </arguments>
+                            <environmentVariables>
+                                <GOOS>linux</GOOS>
+                                <GOARCH>arm64</GOARCH>
+                            </environmentVariables>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 


### PR DESCRIPTION
Pointed out by the wonderful @donbeave

There is an execution for osx-aarch_64, but not execution for linux-aarch_64 in the `pom.xml` file

Building a Java application on Linux ARM fails... The error is:

```
Could not find protoc-gen-validate-0.6.13-linux-aarch_64.exe (io.envoyproxy.protoc-gen-validate:protoc-gen-validate:0.6.13).
```

resolves #680 