### PR TITLE
Improve Development section of readme

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .git/
 .idea/
+.bin/

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Installing PGV can currently only be done from source:
 go get -d github.com/bufbuild/protoc-gen-validate
 ```
 
-> #### 💡 Yes, our go module path is `github.com/bufbuild/protoc-gen-validate` **
+> #### 💡 Yes, our go module path is `github.com/envoyproxy/protoc-gen-validate` **
 not** `bufbuild` this is intentional.
 > Changing the module path is effectively creating a new, independent module. We
 > would prefer not to break our users. The Go team are working on
@@ -123,7 +123,7 @@ into `../generated/example.pb.validate.go`:
 ```sh
 protoc \
   -I . \
-  -I validate.proto \
+  -I path/to/validate/ \ 
   --go_out=":../generated" \
   --validate_out="lang=go:../generated" \
   example.proto

--- a/README.md
+++ b/README.md
@@ -123,8 +123,7 @@ into `../generated/example.pb.validate.go`:
 ```sh
 protoc \
   -I . \
-  -I ${GOPATH}/src \
-  -I ${GOPATH}/src/github.com/bufbuild/protoc-gen-validate \
+  -I validate.proto \
   --go_out=":../generated" \
   --validate_out="lang=go:../generated" \
   example.proto


### PR DESCRIPTION
Highlighted by our valued contributor @HaloWorld in #606, the `development` section of our readme needs some changes. This really does need a lot more work but should do the trick for now. 

resolves #690 