### PR TITLE
Increase dependabot maximum PR limit for maven

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,5 @@ updates:
     directory: "/java" 
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 40
+


### PR DESCRIPTION
It is currently failing [1] as it tries to open more PRs than it is allowed to.

1: https://github.com/bufbuild/protoc-gen-validate/network/updates/495752775