### PR TITLE
Default version bump to prerelease

### DIFF
--- a/.github/actions/github-tag-action/entrypoint.sh
+++ b/.github/actions/github-tag-action/entrypoint.sh
@@ -11,8 +11,8 @@ source=${SOURCE:-.}
 dryrun=${DRY_RUN:-false}
 initial_version=${INITIAL_VERSION:-0.0.0}
 tag_context=${TAG_CONTEXT:-repo}
-prerelease=${PRERELEASE:-false}
-suffix=${PRERELEASE_SUFFIX:-beta}
+prerelease=${PRERELEASE:-true}
+suffix=${PRERELEASE_SUFFIX:-SNAPSHOT}
 verbose=${VERBOSE:-false}
 major_string_token=${MAJOR_STRING_TOKEN:-#major}
 minor_string_token=${MINOR_STRING_TOKEN:-#minor}
@@ -76,17 +76,19 @@ preTagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+(-$suffix\.[0-9]+)$"
 
 # get latest tag that looks like a semver (with or without v)
 case "$tag_context" in
-    *repo*)
+    *repo*) 
         tag="$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)' | grep -E "$tagFmt" | head -n 1)"
         pre_tag="$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)' | grep -E "$preTagFmt" | head -n 1)"
         ;;
-    *branch*)
+    *branch*) 
         tag="$(git tag --list --merged HEAD --sort=-v:refname | grep -E "$tagFmt" | head -n 1)"
         pre_tag="$(git tag --list --merged HEAD --sort=-v:refname | grep -E "$preTagFmt" | head -n 1)"
         ;;
     * ) echo "Unrecognised context"
         exit 1;;
 esac
+
+echo "tag_context=$tag_context"
 
 # if there are none, start tags at INITIAL_VERSION
 if [ -z "$tag" ]
@@ -110,9 +112,11 @@ fi
 
 # get current commit hash for tag
 tag_commit=$(git rev-list -n 1 "$tag")
+echo "tag_commit=$tag_commit"
 
 # get current commit hash
 commit=$(git rev-parse HEAD)
+echo "commit=$commit"
 
 if [ "$tag_commit" == "$commit" ]
 then
@@ -130,22 +134,22 @@ case "$log" in
     *$major_string_token* ) new=$(semver -i major "$tag"); part="major";;
     *$minor_string_token* ) new=$(semver -i minor "$tag"); part="minor";;
     *$patch_string_token* ) new=$(semver -i patch "$tag"); part="patch";;
-    *$none_string_token* )
+    *$none_string_token* ) 
         echo "Default bump was set to none. Skipping..."
         setOutput "new_tag" "$tag"
         setOutput "tag" "$tag"
         exit 0;;
-    * )
+    * ) 
         if [ "$default_semvar_bump" == "none" ]
         then
             echo "Default bump was set to none. Skipping..."
             setOutput "new_tag" "$tag"
             setOutput "tag" "$tag"
-            exit 0
-        else
+            exit 0 
+        else 
             new=$(semver -i "${default_semvar_bump}" "$tag")
-            part=$default_semvar_bump
-        fi
+            part=$default_semvar_bump 
+        fi 
         ;;
 esac
 
@@ -168,14 +172,14 @@ then
       echo -e "Setting ${suffix} pre-tag ${pre_tag} - With pre-tag ${new}"
     fi
     part="pre-$part"
+else
+  echo -e "Bumping tag ${tag} - New tag ${new}"
 fi
 
 if $with_v
 then
     new="v$new"
 fi
-
-echo -e "Bumping tag ${tag} - New tag ${new}"
 
 # as defined in readme if CUSTOM_TAG is used any semver calculations are irrelevant.
 if [ -n "$custom_tag" ]

--- a/.github/actions/github-tag-action/entrypoint.sh
+++ b/.github/actions/github-tag-action/entrypoint.sh
@@ -88,8 +88,6 @@ case "$tag_context" in
         exit 1;;
 esac
 
-echo "tag_context=$tag_context"
-
 # if there are none, start tags at INITIAL_VERSION
 if [ -z "$tag" ]
 then
@@ -112,11 +110,9 @@ fi
 
 # get current commit hash for tag
 tag_commit=$(git rev-list -n 1 "$tag")
-echo "tag_commit=$tag_commit"
 
 # get current commit hash
 commit=$(git rev-parse HEAD)
-echo "commit=$commit"
 
 if [ "$tag_commit" == "$commit" ]
 then


### PR DESCRIPTION
Currently, a merge to main triggers a new `minor` tag. Until we build some confidence into the codebase, I think we should bump releases as a `SNAPSHOT` until verified. This will prevent accidental publishing of unstable releases.