### PR TITLE
fix(bazel): make pgv compiler usable

### DIFF
--- a/bazel/go/BUILD
+++ b/bazel/go/BUILD
@@ -1,0 +1,20 @@
+"""Define our protoc plugin in a rule that can be provided to go_proto_library#compilers
+
+This is in a separate BUILD file from /bazel/BUILD to avoid a dependency on rules_go for all users who load from it.
+
+If you use Gazelle, you can use a directive so that the pgv_plugin_go is automatically added to generated go_proto_library rules.
+See https://github.com/bazelbuild/bazel-gazelle#directives
+
+For example, in some/BUILD.bazel:
+# gazelle:go_grpc_compilers @com_envoyproxy_protoc_gen_validate//bazel/go:pgv_plugin_go, @io_bazel_rules_go//proto:go_grpc
+"""
+load("@io_bazel_rules_go//proto:compiler.bzl", "go_proto_compiler")
+
+go_proto_compiler(
+    name = "pgv_plugin_go",
+    suffix = ".pb.validate.go",
+    valid_archive = False,
+    plugin = "@com_envoyproxy_protoc_gen_validate//:protoc-gen-validate",
+    options = ["lang=go"],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/pgv_proto_library.bzl
+++ b/bazel/pgv_proto_library.bzl
@@ -1,22 +1,17 @@
-load("@io_bazel_rules_go//proto:compiler.bzl", "go_proto_compiler")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load(":protobuf.bzl", "cc_proto_gen_validate", "java_proto_gen_validate")
 
-def pgv_go_proto_library(name, proto = None, deps = [], **kwargs):
-    go_proto_compiler(
-        name = "pgv_plugin_go",
-        suffix = ".pb.validate.go",
-        valid_archive = False,
-        plugin = "//:protoc-gen-validate",
-        options = ["lang=go"],
-    )
+_DEFAULT_GO_PROTOC = ["@io_bazel_rules_go//proto:go_proto"]
 
+def pgv_go_proto_library(name, compilers = _DEFAULT_GO_PROTOC, proto = None, deps = [], **kwargs):
     go_proto_library(
         name = name,
         proto = proto,
-        deps = ["//validate:go_default_library"] + deps,
-        compilers = ["@io_bazel_rules_go//proto:go_proto", "pgv_plugin_go"],
+        deps = ["@com_envoyproxy_protoc_gen_validate//validate:validate"] + deps,
+        compilers = compilers + [
+            "@com_envoyproxy_protoc_gen_validate//bazel/go:pgv_plugin_go",
+        ],
         visibility = ["//visibility:public"],
         **kwargs
     )


### PR DESCRIPTION
It wasn't using absolute labels, so the pgv_go_proto_library macro tries to reference non-existent labels in the users workspace.

Also define the go_proto_compiler rule once, rather than one per go_proto_library.