### PR TITLE
Require wheel at least 0.38.1

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=45",
     "setuptools_scm[toml]>=6.2",
-    "wheel"
+    "wheel>=0.38.1"
 ]
 build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]


### PR DESCRIPTION
The current pypi package fails snyk with ReDoS (Regex Expression Denial of Service) security issue.

[SNYK-PYTHON-WHEEL-3180413](https://security.snyk.io/vuln/SNYK-PYTHON-WHEEL-3180413)