### PR TITLE
Validator bug fix, previously results in error: '[Validator] unknown …

### DIFF
--- a/module/validate.go
+++ b/module/validate.go
@@ -44,7 +44,7 @@ func (m *Module) Execute(targets map[string]pgs.File, pkgs map[string]pgs.Packag
 	if lang == "" {
 		lang = langParamValue
 		m.Assert(lang != "", "`lang` parameter must be set")
-	} else if langParamValue != "" {
+	} else if langParamValue != "" && langParamValue != lang {
 		m.Fail("unknown `lang` parameter")
 	}
 


### PR DESCRIPTION
While running proto buf compiler with --validate_out="lang=go:./proto" was always giving error: '[Validator] unknown lang parameter'. Upon code analysis I found that this condition checks if the langParamValue is not empty and fails with the error message above.
The problem is that it fails even when it should not. Fixed issue, modified this condition to check if the lang parameter value is not equal to the expected language.
Hope this is fine.
Thanks!