### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ language-specific constraint capabilities.
   for optional fields where switching to WKTs is not feasible.
 
   ```protobuf
-  unint32 x = 1 [(validate.rules).uint32 = {ignore_empty: true, gte: 200}];
+  uint32 x = 1 [(validate.rules).uint32 = {ignore_empty: true, gte: 200}];
   ```
 
 ### Bools


### PR DESCRIPTION
Description:

Hello, I'm excited to submit my first contribution to this open-source project! I noticed a typo in the code where unint32 was used instead of uint32, so I made the necessary changes to ensure the code is correct.

Changes Made:

* Replaced all instances of `unint32` with `uint32` for consistency and correctness

Thanks for considering my contribution, and please let me know if there's anything else I can do to help improve the project!