### PR TITLE
Handle github-actions and pip dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+  - package-ecosystem: pip
+    directory: /python
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,23 @@
 version: 2
 updates:
-  - package-ecosystem: "gomod" 
-    directory: "/" 
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "gomod" 
-    directory: "/tests" 
+      interval: weekly
+  - package-ecosystem: gomod
+    directory: /
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "maven" 
-    directory: "/java" 
+      interval: weekly
+  - package-ecosystem: gomod
+    directory: /tests
     schedule:
-      interval: "weekly"
+      interval: weekly
+  - package-ecosystem: maven
+    directory: /java
+    schedule:
+      interval: weekly
     open-pull-requests-limit: 40
-
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
           key: ${{ runner.os }}-build-cache
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VER }}
           cache: true

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0
       - run: git fetch --force --tags
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.19.x
           use-latest: true

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -22,7 +22,7 @@ jobs:
           go-version: 1.19.x
           use-latest: true
           cache: true
-      - uses: goreleaser/goreleaser-action@v2
+      - uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Build and export to Docker
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           load: true


### PR DESCRIPTION
Allows dependabot to handle github-actions and pip dependencies. 
It also includes the update of the available github-actions versions

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>