### PR TITLE
WIP: enhance generated go error messages

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -41,7 +41,7 @@ def pgv_dependencies(maven_repos = _DEFAULT_REPOSITORIES):
             build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
             sha256 = "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30",
             strip_prefix = "zlib-1.2.13",
-            urls = ["https://zlib.net/zlib-1.2.13.tar.gz"],
+            urls = ["https://zlib.net/fossils/zlib-1.2.13.tar.gz"],
         )
 
     if not native.existing_rule("bazel_skylib"):

--- a/templates/go/message.go
+++ b/templates/go/message.go
@@ -14,6 +14,23 @@ const messageTpl = `
 					if err := v.ValidateAll(); err != nil {
 						errors = append(errors, {{ errCause . "err" "embedded message failed validation" }})
 					}
+					if err := v.ValidateAll(); err != nil {
+						if allErr, ok :=  err.(interface { AllErrors() []error }); ok {
+							for _, err := range allErr.AllErrors() {
+								if verr, ok := err.(interface {
+									Field() string
+									Reason() string
+									Cause() error
+								}); ok {
+									errors = append(errors, {{ errIdxCauseReason . (printf "%q+verr.Field()" (printf "%s%s" $f.Name ".") ) "verr.Cause()" "verr.Reason()" }})
+								} else {
+									errors = append(errors, {{ errCause . "err" "fmt.Sprintf(\"embedded message failed validation: %s\", err.Error())" }})
+								}
+							}
+						} else {
+							errors = append(errors, {{ errCause . "err" "fmt.Sprintf(\"embedded message failed validation: %s\", err.Error())" }})
+						}
+					}
 				case interface{ Validate() error }:
 					{{- /* Support legacy validation for messages that were generated with a plugin version prior to existence of ValidateAll() */ -}}
 					if err := v.Validate(); err != nil {

--- a/templates/goshared/register.go
+++ b/templates/goshared/register.go
@@ -20,36 +20,37 @@ func Register(tpl *template.Template, params pgs.Parameters) {
 	fns := goSharedFuncs{pgsgo.InitContext(params)}
 
 	tpl.Funcs(map[string]interface{}{
-		"accessor":      fns.accessor,
-		"byteStr":       fns.byteStr,
-		"cmt":           pgs.C80,
-		"durGt":         fns.durGt,
-		"durLit":        fns.durLit,
-		"durStr":        fns.durStr,
-		"err":           fns.err,
-		"errCause":      fns.errCause,
-		"errIdx":        fns.errIdx,
-		"errIdxCause":   fns.errIdxCause,
-		"errname":       fns.errName,
-		"multierrname":  fns.multiErrName,
-		"inKey":         fns.inKey,
-		"inType":        fns.inType,
-		"isBytes":       fns.isBytes,
-		"lit":           fns.lit,
-		"lookup":        fns.lookup,
-		"msgTyp":        fns.msgTyp,
-		"name":          fns.Name,
-		"oneof":         fns.oneofTypeName,
-		"pkg":           fns.PackageName,
-		"snakeCase":     fns.snakeCase,
-		"tsGt":          fns.tsGt,
-		"tsLit":         fns.tsLit,
-		"tsStr":         fns.tsStr,
-		"typ":           fns.Type,
-		"unwrap":        fns.unwrap,
-		"externalEnums": fns.externalEnums,
-		"enumName":      fns.enumName,
-		"enumPackages":  fns.enumPackages,
+		"accessor":          fns.accessor,
+		"byteStr":           fns.byteStr,
+		"cmt":               pgs.C80,
+		"durGt":             fns.durGt,
+		"durLit":            fns.durLit,
+		"durStr":            fns.durStr,
+		"err":               fns.err,
+		"errCause":          fns.errCause,
+		"errIdxCauseReason": fns.errIdxCauseReason,
+		"errIdx":            fns.errIdx,
+		"errIdxCause":       fns.errIdxCause,
+		"errname":           fns.errName,
+		"multierrname":      fns.multiErrName,
+		"inKey":             fns.inKey,
+		"inType":            fns.inType,
+		"isBytes":           fns.isBytes,
+		"lit":               fns.lit,
+		"lookup":            fns.lookup,
+		"msgTyp":            fns.msgTyp,
+		"name":              fns.Name,
+		"oneof":             fns.oneofTypeName,
+		"pkg":               fns.PackageName,
+		"snakeCase":         fns.snakeCase,
+		"tsGt":              fns.tsGt,
+		"tsLit":             fns.tsLit,
+		"tsStr":             fns.tsStr,
+		"typ":               fns.Type,
+		"unwrap":            fns.unwrap,
+		"externalEnums":     fns.externalEnums,
+		"enumName":          fns.enumName,
+		"enumPackages":      fns.enumPackages,
 	})
 
 	template.Must(tpl.New("msg").Parse(msgTpl))
@@ -110,6 +111,10 @@ func (fns goSharedFuncs) multiErrName(m pgs.Message) pgs.Name {
 }
 
 func (fns goSharedFuncs) errIdxCause(ctx shared.RuleContext, idx, cause string, reason ...interface{}) string {
+	return fns.errIdxCauseReason(ctx, idx, cause, fmt.Sprintf("%q", fmt.Sprint(reason...)))
+}
+
+func (fns goSharedFuncs) errIdxCauseReason(ctx shared.RuleContext, idx string, cause string, reason string) string {
 	f := ctx.Field
 	n := fns.Name(f)
 
@@ -134,12 +139,12 @@ func (fns goSharedFuncs) errIdxCause(ctx shared.RuleContext, idx, cause string, 
 
 	return fmt.Sprintf(`%s{
 		field: %s,
-		reason: %q,
+		reason: %s,
 		%s%s
 	}`,
 		fns.errName(f.Message()),
 		fld,
-		fmt.Sprint(reason...),
+		reason,
 		causeFld,
 		keyFld)
 }


### PR DESCRIPTION
This is a WIP fix for #951. I have not updated any test cases or done any manual testing yet but this does mirror generated code that I have manually edited. 

With these changes all nested fields get their violations put into the top level which turns current errors like

```json
{
  "code": 3,
  "message": "Bad Request",
  "details": [
    {
      "@type": "type.googleapis.com/google.rpc.BadRequest",
      "fieldViolations": [
        {
          "field": "NestedMessage",
          "description": "embedded message failed validation"
        }
      ]
    }
  ]
}
```

Into the much more useful and readable:

```json
{
  "code": 3,
  "message": "Bad Request",
  "details": [
    {
      "@type": "type.googleapis.com/google.rpc.BadRequest",
      "fieldViolations": [
        {
          "field": "NestedMessage.Id",
          "description": "value must be greater than 999"
        },
        {
          "field": "NestedMessage.Email",
          "description": "value must be a valid email address"
        },
        {
          "field": "NestedMessage.Name",
          "description": "value does not match regex pattern \"^[^[0-9]A-Za-z]+( [^[0-9]A-Za-z]+)*$\""
        },
        {
          "field": "NestedMessage.DeeplyNestedMessage.Lat",
          "description": "value must be inside range [-90, 90]"
        }
      ]
    }
  ]
}
```