### PR TITLE
Resolves #969: download Github zlib archive

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -41,7 +41,7 @@ def pgv_dependencies(maven_repos = _DEFAULT_REPOSITORIES):
             build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
             sha256 = "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30",
             strip_prefix = "zlib-1.2.13",
-            urls = ["https://zlib.net/zlib-1.2.13.tar.gz"],
+            urls = ["https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz"],
         )
 
     if not native.existing_rule("bazel_skylib"):


### PR DESCRIPTION
Use a still existing zlib archive download from the [Github project](https://github.com/madler/zlib) rather than from
zlib.net. With this change, `bazel build //cmd/...` works; without this change it fails as documented in #969.