### PR TITLE
Statically build all releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,6 +2,8 @@ builds:
   - main: .
     id: "protoc-gen-validate"
     binary: "protoc-gen-validate"
+    env:
+      - CGO_ENABLED=0
   - main: ./cmd/protoc-gen-validate-cpp
     id: "protoc-gen-validate-cpp"
     binary: "protoc-gen-validate-cpp"


### PR DESCRIPTION
This patch ensures cgo is disabled when building releases for PGV, making the binaries statically-linked for all targeted linux architectures.

Fixes #1051 

Verified locally with `goreleaser build`:

```sh
$ file protoc-gen-validate_linux_amd64_v1/protoc-gen-validate 
protoc-gen-validate: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=tb7sMSnjQh-7-8dwj-lH/T9787ev59A_KyorW6mad/v6PRV3ZwTB6tQWHc6xHc/T7TZq-XGFpsGNognhgR4, stripped

$ file protoc-gen-validate_linux_arm64/protoc-gen-validate
protoc-gen-validate: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=vCwX0aApdg5K4vpifCvn/5E2XJTfVojTMaqafL4ut/QlkXLuZKKxztZHPB5JGZ/Gd0NEotlWEWiD4KPwzjb, stripped

$ file protoc-gen-validate_linux_386/protoc-gen-validate
protoc-gen-validate: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), statically linked, Go BuildID=iWuJ8rzabo476SePT-ZW/SXAZx5iKhXr-qmQoQQy7/3IJw81PJ0cqeBGfOn8B8/FFRtPeAP0sXRDg17K8TB, stripped

```