### PR TITLE
Fix incorrect regex on Person.name field

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ message Person {
   string email = 2 [(validate.rules).string.email = true];
 
   string name = 3 [(validate.rules).string = {
-    pattern:   "^[^[0-9]A-Za-z]+( [^[0-9]A-Za-z]+)*$",
+    pattern:   "^[A-Za-z]+( [A-Za-z]+)*$",
     max_bytes: 256,
   }];
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ p.Id = 1000
 err = p.Validate() // err: Email must be a valid email address
 p.Email = "example@bufbuild.com"
 
-err = p.Validate() // err: Name must match pattern '^[^\d\s]+( [^\d\s]+)*$'
+err = p.Validate() // err: Name must match pattern '^[A-Za-z]+( [A-Za-z]+)*$'
 p.Name = "Protocol Buffer"
 
 err = p.Validate() // err: Home is required

--- a/python/README.md
+++ b/python/README.md
@@ -22,7 +22,7 @@ except ValidationFailed as err:
     print(err)  
     # p.id is not greater than 999
     # p.email is not a valid email
-    # p.name pattern does not match ^[^[0-9]A-Za-z]+( [^[0-9]A-Za-z]+)*$
+    # p.name pattern does not match ^[A-Za-z]+( [A-Za-z]+)*$
     # home is required.
 ```
 


### PR DESCRIPTION
The example regular expression introduced in https://github.com/bufbuild/protoc-gen-validate/commit/10eb9dbe665160f47abfeca829417b56e9b8c73c does not seem to work as intended, due to nesting a negated range inside another range:

```
❯ jshell --class-path ~/.m2/repository/com/google/re2j/re2j/1.7/re2j-1.7.jar
|  Welcome to JShell -- Version 17.0.9
|  For an introduction type: /help intro

jshell> com.google.re2j.Pattern p = com.google.re2j.Pattern.compile("^[^[0-9]A-Za-z]+( [^[0-9]A-Za-z]+)*$");
p ==> ^[^[0-9]A-Za-z]+( [^[0-9]A-Za-z]+)*$

jshell> p.matches(pattern, "Protocol Buffers");
$4 ==> false

jshell> p.matches(pattern, "Matt Brown");
$5 ==> false
```

The nesting of ranges in the example is also redundant - if you are going to specify that only `[A-Za-z]` is valid than including [^0-9]` in that range is not necessary.

This commit fixes the example regular expression to match the example "name" mentioned later in the README.