### PR TITLE
Return a provider from a rule instead of a struct

### DIFF
--- a/bazel/protobuf.bzl
+++ b/bazel/protobuf.bzl
@@ -96,7 +96,7 @@ def _protoc_gen_validate_impl(ctx, lang, protos, out_files, protoc_args, package
         use_default_shell_env = True,
     )
 
-    return struct(
+    return DefaultInfo(
         files = depset(out_files),
     )
 


### PR DESCRIPTION
This is now longer allowed in Bazel 8 and was flipped via `--incompatible_disallow_struct_provider_syntax`.

Once merged, please also backport to the v1.1.1-SNAPSHOTS.