### PR TITLE
Update cc_proto to 0.1.0 and remove rules_proto dep

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,6 +16,6 @@ load("//bazel:extra_dependency_imports.bzl", "pgv_extra_dependency_imports")
 
 pgv_extra_dependency_imports()
 
-load("@maven//:defs.bzl", "pinned_maven_install")
+load("@protobuf_maven//:defs.bzl", "pinned_maven_install")
 
 pinned_maven_install()

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -1,6 +1,10 @@
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@rules_java//java:rules_java_deps.bzl", "rules_java_dependencies")
+load("@rules_jvm_external//:repositories.bzl", "rules_jvm_external_deps")
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
 load("@rules_python//python:pip.bzl", "pip_parse")
@@ -21,6 +25,13 @@ def _pgv_go_dependencies():
     gazelle_dependencies()
 
 def pgv_dependency_imports():
+    bazel_skylib_workspace()
+    bazel_features_deps()
+
+    rules_java_dependencies()
+
+    rules_jvm_external_deps()
+
     # Import @com_google_protobuf's dependencies.
     protobuf_deps()
 

--- a/bazel/extra_dependency_imports.bzl
+++ b/bazel/extra_dependency_imports.bzl
@@ -1,18 +1,19 @@
-load("@bazel_features//:deps.bzl", "bazel_features_deps")
 load("@com_google_protobuf//:protobuf_deps.bzl", "PROTOBUF_MAVEN_ARTIFACTS")
 load("@pgv_pip_deps//:requirements.bzl", "install_deps")
 load("@rules_jvm_external//:defs.bzl", "maven_install")
+load("@rules_jvm_external//:setup.bzl", "rules_jvm_external_setup")
 load("//:dependencies.bzl", "go_third_party")
 
 def pgv_extra_dependency_imports():
-    bazel_features_deps()
-
     install_deps()
 
     # gazelle:repository_macro dependencies.bzl%go_third_party
     go_third_party()
 
+    rules_jvm_external_setup()
+
     maven_install(
+        name = "protobuf_maven",
         artifacts = PROTOBUF_MAVEN_ARTIFACTS,
         maven_install_json = "@com_google_protobuf//:maven_install.json",
         repositories = [

--- a/bazel/protobuf.bzl
+++ b/bazel/protobuf.bzl
@@ -1,6 +1,6 @@
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
-load("@bazel_tools//tools/jdk:toolchain_utils.bzl", "find_java_runtime_toolchain", "find_java_toolchain")
-load("@rules_proto//proto:defs.bzl", "ProtoInfo")
+load("@bazel_tools//tools/jdk:toolchain_utils.bzl", "find_java_toolchain")
+load("@com_google_protobuf//bazel/common:proto_info.bzl", "ProtoInfo")
 
 # Borrowed from https://github.com/grpc/grpc-java/blob/v1.28.0/java_grpc_library.bzl#L59
 # "repository" here is for Bazel builds that span multiple WORKSPACES.

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -14,6 +14,59 @@ def pgv_dependencies(maven_repos = _DEFAULT_REPOSITORIES):
             ],
         )
 
+    if not native.existing_rule("rules_python"):
+        http_archive(
+            name = "rules_python",
+            sha256 = "4912ced70dc1a2a8e4b86cec233b192ca053e82bc72d877b98e126156e8f228d",
+            strip_prefix = "rules_python-0.32.2",
+            url = "https://github.com/bazelbuild/rules_python/releases/download/0.32.2/rules_python-0.32.2.tar.gz",
+        )
+
+    if not native.existing_rule("rules_cc"):
+        http_archive(
+            name = "rules_cc",
+            sha256 = "4b12149a041ddfb8306a8fd0e904e39d673552ce82e4296e96fac9cbf0780e59",
+            strip_prefix = "rules_cc-0.1.0",
+            url = "https://github.com/bazelbuild/rules_cc/releases/download/0.1.0/rules_cc-0.1.0.tar.gz",
+        )
+
+    if not native.existing_rule("bazel_features"):
+        http_archive(
+            name = "bazel_features",
+            sha256 = "8b1c9b7558498000f5adebbc584b7bf15b6b2bf181448a66f6b2fc5b4c84231c",
+            strip_prefix = "bazel_features-1.23.0",
+            url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.23.0/bazel_features-v1.23.0.tar.gz",
+        )
+
+    if not native.existing_rule("rules_license"):
+        http_archive(
+            name = "rules_license",
+            urls = [
+                "https://mirror.bazel.build/github.com/bazelbuild/rules_license/releases/download/1.0.0/rules_license-1.0.0.tar.gz",
+                "https://github.com/bazelbuild/rules_license/releases/download/1.0.0/rules_license-1.0.0.tar.gz",
+            ],
+            sha256 = "26d4021f6898e23b82ef953078389dd49ac2b5618ac564ade4ef87cced147b38",
+        )
+
+    if not native.existing_rule("rules_jvm_external"):
+        RULES_JVM_EXTERNAL_TAG = "6.6"
+        RULES_JVM_EXTERNAL_SHA = "3afe5195069bd379373528899c03a3072f568d33bd96fe037bd43b1f590535e7"
+        http_archive(
+            name = "rules_jvm_external",
+            strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
+            sha256 = RULES_JVM_EXTERNAL_SHA,
+            url = "https://github.com/bazel-contrib/rules_jvm_external/releases/download/%s/rules_jvm_external-%s.tar.gz" % (RULES_JVM_EXTERNAL_TAG, RULES_JVM_EXTERNAL_TAG),
+        )
+
+    if not native.existing_rule("rules_java"):
+        http_archive(
+            name = "rules_java",
+            urls = [
+                "https://github.com/bazelbuild/rules_java/releases/download/8.6.3/rules_java-8.6.3.tar.gz",
+            ],
+            sha256 = "6d8c6d5cd86fed031ee48424f238fa35f33abc9921fd97dd4ae1119a29fc807f",
+        )
+
     if not native.existing_rule("bazel_gazelle"):
         http_archive(
             name = "bazel_gazelle",
@@ -24,9 +77,18 @@ def pgv_dependencies(maven_repos = _DEFAULT_REPOSITORIES):
     if not native.existing_rule("com_google_protobuf"):
         http_archive(
             name = "com_google_protobuf",
-            url = "https://github.com/protocolbuffers/protobuf/releases/download/v27.0/protobuf-27.0.tar.gz",
-            sha256 = "da288bf1daa6c04d03a9051781caa52aceb9163586bff9aa6cfb12f69b9395aa",
-            strip_prefix = "protobuf-27.0",
+            url = "https://github.com/protocolbuffers/protobuf/releases/download/v29.2/protobuf-29.2.tar.gz",
+            sha256 = "63150aba23f7a90fd7d87bdf514e459dd5fe7023fdde01b56ac53335df64d4bd",
+            strip_prefix = "protobuf-29.2",
+        )
+
+    # NOTE: Even though this is not directly used, rules_go requires this still.
+    if not native.existing_rule("rules_proto"):
+        http_archive(
+            name = "rules_proto",
+            sha256 = "14a225870ab4e91869652cfd69ef2028277fc1dc4910d65d353b62d6e0ae21f4",
+            strip_prefix = "rules_proto-7.1.0",
+            url = "https://github.com/bazelbuild/rules_proto/releases/download/7.1.0/rules_proto-7.1.0.tar.gz",
         )
 
     # TODO(akonradi): This shouldn't be necessary since the same http_archive block is imported by
@@ -43,8 +105,11 @@ def pgv_dependencies(maven_repos = _DEFAULT_REPOSITORIES):
     if not native.existing_rule("bazel_skylib"):
         http_archive(
             name = "bazel_skylib",
-            sha256 = "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
-            urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz"],
+            sha256 = "bc283cdfcd526a52c3201279cda4bc298652efa898b10b4db0837dc51652756f",
+            urls = [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
+            ],
         )
 
     if not native.existing_rule("com_google_re2j"):
@@ -77,28 +142,4 @@ def pgv_dependencies(maven_repos = _DEFAULT_REPOSITORIES):
             artifact = "commons-validator:commons-validator:1.6",
             artifact_sha256 = "bd62795d7068a69cbea333f6dbf9c9c1a6ad7521443fb57202a44874f240ba25",
             server_urls = maven_repos,
-        )
-
-    if not native.existing_rule("rules_python"):
-        http_archive(
-            name = "rules_python",
-            sha256 = "4912ced70dc1a2a8e4b86cec233b192ca053e82bc72d877b98e126156e8f228d",
-            strip_prefix = "rules_python-0.32.2",
-            url = "https://github.com/bazelbuild/rules_python/releases/download/0.32.2/rules_python-0.32.2.tar.gz",
-        )
-
-    if not native.existing_rule("rules_proto"):
-        http_archive(
-            name = "rules_proto",
-            sha256 = "303e86e722a520f6f326a50b41cfc16b98fe6d1955ce46642a5b7a67c11c0f5d",
-            strip_prefix = "rules_proto-6.0.0",
-            url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.0/rules_proto-6.0.0.tar.gz",
-        )
-
-    if not native.existing_rule("rules_cc"):
-        http_archive(
-            name = "rules_cc",
-            sha256 = "2037875b9a4456dce4a79d112a8ae885bbc4aad968e6587dca6e64f3a0900cdf",
-            strip_prefix = "rules_cc-0.0.9",
-            url = "https://github.com/bazelbuild/rules_cc/releases/download/0.0.9/rules_cc-0.0.9.tar.gz",
         )

--- a/java/pgv-java-grpc/src/test/proto/BUILD.bazel
+++ b/java/pgv-java-grpc/src/test/proto/BUILD.bazel
@@ -1,6 +1,6 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "io_envoyproxy_pgv_grpc_proto",

--- a/java/pgv-java-stub/src/test/proto/BUILD.bazel
+++ b/java/pgv-java-stub/src/test/proto/BUILD.bazel
@@ -1,5 +1,5 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "io_envoyproxy_pvg_cases_proto",

--- a/python/requirements.in
+++ b/python/requirements.in
@@ -3,5 +3,5 @@
 # See requirements_test.py for more context.
 validate-email>=1.3
 Jinja2>=2.11.1
-protobuf>=5.27.0
+protobuf>=5.29.2
 astunparse>=1.6.3; python_version<"3.10"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -4,14 +4,10 @@
 #
 #    bazel run //python:requirements.update
 #
-astunparse==1.6.3 \
-    --hash=sha256:5ad93a8456f0d084c3456d059fd9a92cce667963232cbf763eac3bc5b7940872 \
-    --hash=sha256:c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8
-    # via -r requirements.in
 jinja2==3.1.4 \
     --hash=sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369 \
     --hash=sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d
-    # via -r requirements.in
+    # via -r python/requirements.in
 markupsafe==2.1.5 \
     --hash=sha256:00e046b6dd71aa03a41079792f8473dc494d564611a8f89bbbd7cb93295ebdcf \
     --hash=sha256:075202fa5b72c86ad32dc7d0b56024ebdbcf2048c0ba09f1cde31bfdd57bcfff \
@@ -74,27 +70,19 @@ markupsafe==2.1.5 \
     --hash=sha256:fce659a462a1be54d2ffcacea5e3ba2d74daa74f30f5f143fe0c58636e355fdd \
     --hash=sha256:ffee1f21e5ef0d712f9033568f8344d5da8cc2869dbd08d87c84656e6a2d2f68
     # via jinja2
-protobuf==5.29.1 \
-    --hash=sha256:012ce28d862ff417fd629285aca5d9772807f15ceb1a0dbd15b88f58c776c98c \
-    --hash=sha256:027fbcc48cea65a6b17028510fdd054147057fa78f4772eb547b9274e5219331 \
-    --hash=sha256:1fc55267f086dd4050d18ef839d7bd69300d0d08c2a53ca7df3920cc271a3c34 \
-    --hash=sha256:22c1f539024241ee545cbcb00ee160ad1877975690b16656ff87dde107b5f110 \
-    --hash=sha256:32600ddb9c2a53dedc25b8581ea0f1fd8ea04956373c0c07577ce58d312522e0 \
-    --hash=sha256:50879eb0eb1246e3a5eabbbe566b44b10348939b7cc1b267567e8c3d07213853 \
-    --hash=sha256:5a41deccfa5e745cef5c65a560c76ec0ed8e70908a67cc8f4da5fce588b50d57 \
-    --hash=sha256:683be02ca21a6ffe80db6dd02c0b5b2892322c59ca57fd6c872d652cb80549cb \
-    --hash=sha256:8ee1461b3af56145aca2800e6a3e2f928108c749ba8feccc6f5dd0062c410c0d \
-    --hash=sha256:b5ba1d0e4c8a40ae0496d0e2ecfdbb82e1776928a205106d14ad6985a09ec155 \
-    --hash=sha256:d473655e29c0c4bbf8b69e9a8fb54645bc289dead6d753b952e7aa660254ae18
-    # via -r requirements.in
-six==1.16.0 \
-    --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
-    --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
-    # via astunparse
+protobuf==5.29.2 \
+    --hash=sha256:13d6d617a2a9e0e82a88113d7191a1baa1e42c2cc6f5f1398d3b054c8e7e714a \
+    --hash=sha256:2d2e674c58a06311c8e99e74be43e7f3a8d1e2b2fdf845eaa347fbd866f23355 \
+    --hash=sha256:36000f97ea1e76e8398a3f02936aac2a5d2b111aae9920ec1b769fc4a222c4d9 \
+    --hash=sha256:494229ecd8c9009dd71eda5fd57528395d1eacdf307dbece6c12ad0dd09e912e \
+    --hash=sha256:842de6d9241134a973aab719ab42b008a18a90f9f07f06ba480df268f86432f9 \
+    --hash=sha256:a0c53d78383c851bfa97eb42e3703aefdc96d2036a41482ffd55dc5f529466eb \
+    --hash=sha256:b2cc8e8bb7c9326996f0e160137b0861f1a82162502658df2951209d0cb0309e \
+    --hash=sha256:b6b0d416bbbb9d4fbf9d0561dbfc4e324fd522f61f7af0fe0f282ab67b22477e \
+    --hash=sha256:c12ba8249f5624300cf51c3d0bfe5be71a60c63e4dcf51ffe9a68771d958c851 \
+    --hash=sha256:e621a98c0201a7c8afe89d9646859859be97cb22b8bf1d8eacfd90d5bda2eb19 \
+    --hash=sha256:fde4554c0e578a5a0bcc9a276339594848d1e89f9ea47b4427c80e5d72f90181
+    # via -r python/requirements.in
 validate-email==1.3 \
     --hash=sha256:784719dc5f780be319cdd185dc85dd93afebdb6ebb943811bc4c7c5f9c72aeaf
-    # via -r requirements.in
-wheel==0.45.1 \
-    --hash=sha256:661e1abd9198507b1409a20c02106d9670b2576e916d58f520316666abca6729 \
-    --hash=sha256:708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248
-    # via astunparse
+    # via -r python/requirements.in

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -25,7 +25,7 @@ packages = find:
 install_requires =
     validate-email>=1.3
     Jinja2>=2.11.1
-    protobuf>=5.27.0
+    protobuf>=5.29.2
     astunparse>=1.6.3; python_version<"3.10"
 python_requires = >=3.6
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ build==0.3.0
 twine==3.3.0
 wheel==0.38.1
 setuptools==70.0.0
-protobuf==5.27.0
+protobuf==5.29.2
 setuptools_scm[toml]>=6.2

--- a/tests/generation/multi_file_java_test/BUILD
+++ b/tests/generation/multi_file_java_test/BUILD
@@ -1,9 +1,6 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_binary")
-load("@rules_proto//proto:defs.bzl", "proto_library")
-load(
-    "//bazel:pgv_proto_library.bzl",
-    "pgv_cc_proto_library",
-)
+load("//bazel:pgv_proto_library.bzl", "pgv_cc_proto_library")
 
 # gazelle:go_generate_proto false
 

--- a/tests/harness/BUILD
+++ b/tests/harness/BUILD
@@ -1,8 +1,8 @@
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("@rules_java//java:defs.bzl", "java_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_python//python:proto.bzl", "py_proto_library")
 
 proto_library(

--- a/tests/harness/cases/BUILD
+++ b/tests/harness/cases/BUILD
@@ -1,5 +1,5 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_java//java:defs.bzl", "java_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_python//python:proto.bzl", "py_proto_library")
 load(
     "//bazel:pgv_proto_library.bzl",

--- a/tests/harness/cases/other_package/BUILD
+++ b/tests/harness/cases/other_package/BUILD
@@ -1,7 +1,7 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@rules_java//java:defs.bzl", "java_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_python//python:proto.bzl", "py_proto_library")
 load(
     "//bazel:pgv_proto_library.bzl",
@@ -71,6 +71,6 @@ pgv_java_proto_library(
 
 py_proto_library(
     name = "embed_python_proto",
-    deps = [":embed_proto"],
     visibility = ["//visibility:public"],
+    deps = [":embed_proto"],
 )

--- a/tests/harness/cases/sort/BUILD
+++ b/tests/harness/cases/sort/BUILD
@@ -1,7 +1,7 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@rules_java//java:defs.bzl", "java_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_python//python:proto.bzl", "py_proto_library")
 load(
     "//bazel:pgv_proto_library.bzl",
@@ -71,6 +71,6 @@ pgv_java_proto_library(
 
 py_proto_library(
     name = "sort_python_proto",
-    deps = [":sort_proto"],
     visibility = ["//visibility:public"],
+    deps = [":sort_proto"],
 )

--- a/tests/harness/cases/yet_another_package/BUILD
+++ b/tests/harness/cases/yet_another_package/BUILD
@@ -1,7 +1,7 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@rules_java//java:defs.bzl", "java_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_python//python:proto.bzl", "py_proto_library")
 load(
     "//bazel:pgv_proto_library.bzl",
@@ -71,6 +71,6 @@ pgv_java_proto_library(
 
 py_proto_library(
     name = "embed_python_proto",
-    deps = [":embed_proto"],
     visibility = ["//visibility:public"],
+    deps = [":embed_proto"],
 )

--- a/tests/harness/cc/BUILD
+++ b/tests/harness/cc/BUILD
@@ -1,5 +1,6 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_proto_library", "cc_test")
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 
 MSVC_C_OPTS = [
     "-WX",

--- a/validate/BUILD
+++ b/validate/BUILD
@@ -1,8 +1,8 @@
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library")
 load("@rules_java//java:defs.bzl", "java_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_python//python:proto.bzl", "py_proto_library")
 
 package(


### PR DESCRIPTION
Closes https://github.com/bufbuild/protoc-gen-validate/issues/1199

rules_proto has been deprecated and should no longer be used.

rules_cc removed the proto-related bazel rules as of 0.1.0. Instead, these rules now live in com_google_protobuf and should be used from there.

Several other dependencies also had to be updated to support the changes in com_google_protobuf and cc_proto.