### PR TITLE
Migrate to cc_proto_library from com_google_protobuf

### DIFF
--- a/bazel/pgv_proto_library.bzl
+++ b/bazel/pgv_proto_library.bzl
@@ -1,3 +1,4 @@
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load(":protobuf.bzl", "cc_proto_gen_validate", "java_proto_gen_validate")
@@ -30,7 +31,7 @@ def pgv_cc_proto_library(
       **kargs: other keyword arguments that are passed to cc_library.
     """
 
-    native.cc_proto_library(
+    cc_proto_library(
         name = name + "_cc_proto",
         deps = deps,
     )

--- a/tests/harness/BUILD
+++ b/tests/harness/BUILD
@@ -1,6 +1,6 @@
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("@rules_java//java:defs.bzl", "java_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_python//python:proto.bzl", "py_proto_library")

--- a/tests/harness/cc/BUILD
+++ b/tests/harness/cc/BUILD
@@ -1,4 +1,5 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_proto_library", "cc_test")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
 MSVC_C_OPTS = [

--- a/validate/BUILD
+++ b/validate/BUILD
@@ -1,6 +1,7 @@
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_java//java:defs.bzl", "java_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_python//python:proto.bzl", "py_proto_library")


### PR DESCRIPTION
Closes https://github.com/bufbuild/protoc-gen-validate/issues/1199

This is a more minimal change to simply migrate away from rules_cc's  cc_proto_library without updating all the external deps.

This will prepare for the upcoming 0.1.X release of rules_cc where cc_proto_library is removed.